### PR TITLE
825_htt

### DIFF
--- a/H2TauTau/python/h2TauTauMiniAOD_generic_cfg.py
+++ b/H2TauTau/python/h2TauTauMiniAOD_generic_cfg.py
@@ -190,6 +190,7 @@ def createProcess(runOnMC=True, channel='tau-mu', runSVFit=False, runMVAETmiss=F
     # Message logger setup.
     process.load("FWCore.MessageLogger.MessageLogger_cfi")
     process.MessageLogger.cerr.FwkReport.reportEvery = reportInterval
+    process.MessageLogger.suppressWarning = cms.untracked.vstring('cmgDiTau')
     process.options = cms.untracked.PSet(wantSummary=cms.untracked.bool(True))
 
     process.options = cms.untracked.PSet(

--- a/H2TauTau/python/proto/samples/summer16/htt_common.py
+++ b/H2TauTau/python/proto/samples/summer16/htt_common.py
@@ -13,6 +13,7 @@ from CMGTools.RootTools.samples.samples_13TeV_DATA2016 import SingleMuon_Run2016
 from CMGTools.RootTools.samples.samples_13TeV_DATA2016 import SingleMuon_Run2016F_23Sep2016, SingleElectron_Run2016F_23Sep2016, MuonEG_Run2016F_23Sep2016, Tau_Run2016F_23Sep2016
 from CMGTools.RootTools.samples.samples_13TeV_DATA2016 import SingleMuon_Run2016G_23Sep2016, SingleElectron_Run2016G_23Sep2016, MuonEG_Run2016G_23Sep2016, Tau_Run2016G_23Sep2016
 from CMGTools.RootTools.samples.samples_13TeV_RunIISummer16MiniAODv2 import ZZTo4L, WZTo1L3Nu, WWTo1L1Nu2Q, WZTo1L1Nu2Q, ZZTo2L2Q, WZTo2L2Q, VVTo2L2Nu, WZTo3LNu_amcatnlo
+from CMGTools.RootTools.samples.samples_13TeV_DATA2016 import Tau_Run2016B_03Feb2017_v2, Tau_Run2016C_03Feb2017, Tau_Run2016D_03Feb2017, Tau_Run2016E_03Feb2017, Tau_Run2016F_03Feb2017, Tau_Run2016G_03Feb2017, Tau_Run2016H_03Feb2017_v2, Tau_Run2016H_03Feb2017_v3
 
 # from CMGTools.RootTools.samples.samples_13TeV_RunIISummer16MiniAODv2 import DYJetsToLL_M10to50_ext1
 # DY1JetsToLL_M50_LO, DY2JetsToLL_M50_LO, DY3JetsToLL_M50_LO, DY4JetsToLL_M50_LO,
@@ -114,7 +115,7 @@ backgrounds_ele += QCDPtbcToE
 data_single_muon = [SingleMuon_Run2016B_23Sep2016, SingleMuon_Run2016C_23Sep2016, SingleMuon_Run2016D_23Sep2016, SingleMuon_Run2016E_23Sep2016, SingleMuon_Run2016F_23Sep2016, SingleMuon_Run2016G_23Sep2016]
 data_single_electron = [SingleElectron_Run2016B_23Sep2016, SingleElectron_Run2016C_23Sep2016, SingleElectron_Run2016D_23Sep2016, SingleElectron_Run2016E_23Sep2016, SingleElectron_Run2016F_23Sep2016, SingleElectron_Run2016G_23Sep2016]
 data_muon_electron = [MuonEG_Run2016B_23Sep2016, MuonEG_Run2016C_23Sep2016, MuonEG_Run2016D_23Sep2016, MuonEG_Run2016E_23Sep2016, MuonEG_Run2016F_23Sep2016, MuonEG_Run2016G_23Sep2016]
-data_tau = [Tau_Run2016B_23Sep2016, Tau_Run2016C_23Sep2016, Tau_Run2016D_23Sep2016, Tau_Run2016E_23Sep2016, Tau_Run2016F_23Sep2016, Tau_Run2016G_23Sep2016]
+data_tau = [Tau_Run2016B_03Feb2017_v2, Tau_Run2016C_03Feb2017, Tau_Run2016D_03Feb2017, Tau_Run2016E_03Feb2017, Tau_Run2016F_03Feb2017, Tau_Run2016G_03Feb2017, Tau_Run2016H_03Feb2017_v2, Tau_Run2016H_03Feb2017_v3]
 
 for sample in data_single_muon + data_single_electron + data_muon_electron + data_tau:
     sample.json = json

--- a/RootTools/python/samples/samples_13TeV_DATA2016.py
+++ b/RootTools/python/samples/samples_13TeV_DATA2016.py
@@ -264,31 +264,31 @@ dataSamples_23Sep2016PlusPrompt = dataSamples_23Sep2016 + dataSamples_Run2016H_v
 
 ### ----------------------------- Run2016B v1 03Feb2017 ----------------------------------------
 
-JetHT_Run2016B_03Feb2017_v1       = kreator.makeDataComponent("JetHT_Run2016B-03Feb2017-v1"      , "/JetHT/Run2016B-03Feb2017_ver1-v1/MINIAOD"         , "CMS", ".*root", json)
-HTMHT_Run2016B_03Feb2017_v1       = kreator.makeDataComponent("HTMHT_Run2016B-03Feb2017-v1"      , "/HTMHT/Run2016B-03Feb2017_ver1-v1/MINIAOD"         , "CMS", ".*root", json)
-MET_Run2016B_03Feb2017_v1         = kreator.makeDataComponent("MET_Run2016B-03Feb2017-v1"        , "/MET/Run2016B-03Feb2017_ver1-v1/MINIAOD"           , "CMS", ".*root", json)
-SingleElectron_Run2016B_03Feb2017_v1 = kreator.makeDataComponent("SingleElectron_Run2016B_03Feb2017-v1", "/SingleElectron/Run2016B-03Feb2017_ver1-v1/MINIAOD", "CMS", ".*root", json)
-SingleMuon_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("SingleMuon_Run2016B-03Feb2017-v1" , "/SingleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
-SinglePhoton_Run2016B_03Feb2017_v1= kreator.makeDataComponent("SinglePhoton_Run2016B_03Feb2017-v1"  , "/SinglePhoton/Run2016B-03Feb2017_ver1-v1/MINIAOD"  , "CMS", ".*root", json)
-DoubleEG_Run2016B_03Feb2017_v1    = kreator.makeDataComponent("DoubleEG_Run2016B-03Feb2017-v1"   , "/DoubleEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"      , "CMS", ".*root", json)
-MuonEG_Run2016B_03Feb2017_v1     = kreator.makeDataComponent("MuonEG_Run2016B-03Feb2017-v1"     , "/MuonEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"        , "CMS", ".*root", json)
-DoubleMuon_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("DoubleMuon_Run2016B-03Feb2017-v1" , "/DoubleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
-Tau_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("Tau_Run2016B-03Feb2017-v1" , "/Tau/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
+JetHT_Run2016B_03Feb2017_v1       = kreator.makeDataComponent("JetHT_Run2016B_03Feb2017_v1"      , "/JetHT/Run2016B-03Feb2017_ver1-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016B_03Feb2017_v1       = kreator.makeDataComponent("HTMHT_Run2016B_03Feb2017_v1"      , "/HTMHT/Run2016B-03Feb2017_ver1-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016B_03Feb2017_v1         = kreator.makeDataComponent("MET_Run2016B_03Feb2017_v1"        , "/MET/Run2016B-03Feb2017_ver1-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016B_03Feb2017_v1 = kreator.makeDataComponent("SingleElectron_Run2016B_03Feb2017_v1", "/SingleElectron/Run2016B-03Feb2017_ver1-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("SingleMuon_Run2016B_03Feb2017_v1" , "/SingleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016B_03Feb2017_v1= kreator.makeDataComponent("SinglePhoton_Run2016B_03Feb2017_v1"  , "/SinglePhoton/Run2016B-03Feb2017_ver1-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016B_03Feb2017_v1    = kreator.makeDataComponent("DoubleEG_Run2016B_03Feb2017_v1"   , "/DoubleEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016B_03Feb2017_v1     = kreator.makeDataComponent("MuonEG_Run2016B_03Feb2017_v1"     , "/MuonEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("DoubleMuon_Run2016B_03Feb2017_v1" , "/DoubleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("Tau_Run2016B_03Feb2017_v1" , "/Tau/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
 
 dataSamples_Run2016B_03Feb2017_v1 = [JetHT_Run2016B_03Feb2017_v1, HTMHT_Run2016B_03Feb2017_v1, MET_Run2016B_03Feb2017_v1, SingleElectron_Run2016B_03Feb2017_v1, SingleMuon_Run2016B_03Feb2017_v1, SinglePhoton_Run2016B_03Feb2017_v1, DoubleEG_Run2016B_03Feb2017_v1, MuonEG_Run2016B_03Feb2017_v1, DoubleMuon_Run2016B_03Feb2017_v1, Tau_Run2016B_03Feb2017_v1]
 
 ### ----------------------------- Run2016B v2 03Feb2017 ----------------------------------------
 
-JetHT_Run2016B_03Feb2017_v2       = kreator.makeDataComponent("JetHT_Run2016B-03Feb2017-v2"      , "/JetHT/Run2016B-03Feb2017_ver2-v2/MINIAOD"         , "CMS", ".*root", json)
-HTMHT_Run2016B_03Feb2017_v2       = kreator.makeDataComponent("HTMHT_Run2016B-03Feb2017-v2"      , "/HTMHT/Run2016B-03Feb2017_ver2-v2/MINIAOD"         , "CMS", ".*root", json)
-MET_Run2016B_03Feb2017_v2         = kreator.makeDataComponent("MET_Run2016B-03Feb2017-v2"        , "/MET/Run2016B-03Feb2017_ver2-v2/MINIAOD"           , "CMS", ".*root", json)
-SingleElectron_Run2016B_03Feb2017_v2 = kreator.makeDataComponent("SingleElectron_Run2016B_03Feb2017-v2", "/SingleElectron/Run2016B-03Feb2017_ver2-v2/MINIAOD", "CMS", ".*root", json)
-SingleMuon_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("SingleMuon_Run2016B-03Feb2017-v2" , "/SingleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
-SinglePhoton_Run2016B_03Feb2017_v2= kreator.makeDataComponent("SinglePhoton_Run2016B_03Feb2017-v2"  , "/SinglePhoton/Run2016B-03Feb2017_ver2-v2/MINIAOD"  , "CMS", ".*root", json)
-DoubleEG_Run2016B_03Feb2017_v2    = kreator.makeDataComponent("DoubleEG_Run2016B-03Feb2017-v2"   , "/DoubleEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"      , "CMS", ".*root", json)
-MuonEG_Run2016B_03Feb2017_v2     = kreator.makeDataComponent("MuonEG_Run2016B-03Feb2017-v2"     , "/MuonEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"        , "CMS", ".*root", json)
-DoubleMuon_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("DoubleMuon_Run2016B-03Feb2017-v2" , "/DoubleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
-Tau_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("Tau_Run2016B-03Feb2017-v2" , "/Tau/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
+JetHT_Run2016B_03Feb2017_v2       = kreator.makeDataComponent("JetHT_Run2016B_03Feb2017_v2"      , "/JetHT/Run2016B-03Feb2017_ver2-v2/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016B_03Feb2017_v2       = kreator.makeDataComponent("HTMHT_Run2016B_03Feb2017_v2"      , "/HTMHT/Run2016B-03Feb2017_ver2-v2/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016B_03Feb2017_v2         = kreator.makeDataComponent("MET_Run2016B_03Feb2017_v2"        , "/MET/Run2016B-03Feb2017_ver2-v2/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016B_03Feb2017_v2 = kreator.makeDataComponent("SingleElectron_Run2016B_03Feb2017_v2", "/SingleElectron/Run2016B-03Feb2017_ver2-v2/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("SingleMuon_Run2016B_03Feb2017_v2" , "/SingleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016B_03Feb2017_v2= kreator.makeDataComponent("SinglePhoton_Run2016B_03Feb2017_v2"  , "/SinglePhoton/Run2016B-03Feb2017_ver2-v2/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016B_03Feb2017_v2    = kreator.makeDataComponent("DoubleEG_Run2016B_03Feb2017_v2"   , "/DoubleEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016B_03Feb2017_v2     = kreator.makeDataComponent("MuonEG_Run2016B_03Feb2017_v2"     , "/MuonEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("DoubleMuon_Run2016B_03Feb2017_v2" , "/DoubleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("Tau_Run2016B_03Feb2017_v2" , "/Tau/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
 
 dataSamples_Run2016B_03Feb2017_v2 = [JetHT_Run2016B_03Feb2017_v2, HTMHT_Run2016B_03Feb2017_v2, MET_Run2016B_03Feb2017_v2, SingleElectron_Run2016B_03Feb2017_v2, SingleMuon_Run2016B_03Feb2017_v2, SinglePhoton_Run2016B_03Feb2017_v2, DoubleEG_Run2016B_03Feb2017_v2, MuonEG_Run2016B_03Feb2017_v2, DoubleMuon_Run2016B_03Feb2017_v2, Tau_Run2016B_03Feb2017_v2]
 

--- a/RootTools/python/samples/samples_13TeV_DATA2016.py
+++ b/RootTools/python/samples/samples_13TeV_DATA2016.py
@@ -262,7 +262,150 @@ dataSamples_23Sep2016 = dataSamples_Run2016B_23Sep2016 + dataSamples_Run2016C_23
 ### Dataset corresponding to the full Run2016 with re-reco + prompt
 dataSamples_23Sep2016PlusPrompt = dataSamples_23Sep2016 + dataSamples_Run2016H_v2 + dataSamples_Run2016H_v3
 
-dataSamples = dataSamples_PromptReco + dataSamples_23Sep2016
+### ----------------------------- Run2016B v1 03Feb2017 ----------------------------------------
+
+JetHT_Run2016B_03Feb2017_v1       = kreator.makeDataComponent("JetHT_Run2016B-03Feb2017-v1"      , "/JetHT/Run2016B-03Feb2017_ver1-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016B_03Feb2017_v1       = kreator.makeDataComponent("HTMHT_Run2016B-03Feb2017-v1"      , "/HTMHT/Run2016B-03Feb2017_ver1-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016B_03Feb2017_v1         = kreator.makeDataComponent("MET_Run2016B-03Feb2017-v1"        , "/MET/Run2016B-03Feb2017_ver1-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016B_03Feb2017_v1 = kreator.makeDataComponent("SingleElectron_Run2016B_03Feb2017-v1", "/SingleElectron/Run2016B-03Feb2017_ver1-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("SingleMuon_Run2016B-03Feb2017-v1" , "/SingleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016B_03Feb2017_v1= kreator.makeDataComponent("SinglePhoton_Run2016B_03Feb2017-v1"  , "/SinglePhoton/Run2016B-03Feb2017_ver1-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016B_03Feb2017_v1    = kreator.makeDataComponent("DoubleEG_Run2016B-03Feb2017-v1"   , "/DoubleEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016B_03Feb2017_v1     = kreator.makeDataComponent("MuonEG_Run2016B-03Feb2017-v1"     , "/MuonEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("DoubleMuon_Run2016B-03Feb2017-v1" , "/DoubleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("Tau_Run2016B-03Feb2017-v1" , "/Tau/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
+
+dataSamples_Run2016B_03Feb2017_v1 = [JetHT_Run2016B_03Feb2017_v1, HTMHT_Run2016B_03Feb2017_v1, MET_Run2016B_03Feb2017_v1, SingleElectron_Run2016B_03Feb2017_v1, SingleMuon_Run2016B_03Feb2017_v1, SinglePhoton_Run2016B_03Feb2017_v1, DoubleEG_Run2016B_03Feb2017_v1, MuonEG_Run2016B_03Feb2017_v1, DoubleMuon_Run2016B_03Feb2017_v1, Tau_Run2016B_03Feb2017_v1]
+
+### ----------------------------- Run2016B v2 03Feb2017 ----------------------------------------
+
+JetHT_Run2016B_03Feb2017_v2       = kreator.makeDataComponent("JetHT_Run2016B-03Feb2017-v2"      , "/JetHT/Run2016B-03Feb2017_ver2-v2/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016B_03Feb2017_v2       = kreator.makeDataComponent("HTMHT_Run2016B-03Feb2017-v2"      , "/HTMHT/Run2016B-03Feb2017_ver2-v2/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016B_03Feb2017_v2         = kreator.makeDataComponent("MET_Run2016B-03Feb2017-v2"        , "/MET/Run2016B-03Feb2017_ver2-v2/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016B_03Feb2017_v2 = kreator.makeDataComponent("SingleElectron_Run2016B_03Feb2017-v2", "/SingleElectron/Run2016B-03Feb2017_ver2-v2/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("SingleMuon_Run2016B-03Feb2017-v2" , "/SingleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016B_03Feb2017_v2= kreator.makeDataComponent("SinglePhoton_Run2016B_03Feb2017-v2"  , "/SinglePhoton/Run2016B-03Feb2017_ver2-v2/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016B_03Feb2017_v2    = kreator.makeDataComponent("DoubleEG_Run2016B-03Feb2017-v2"   , "/DoubleEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016B_03Feb2017_v2     = kreator.makeDataComponent("MuonEG_Run2016B-03Feb2017-v2"     , "/MuonEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("DoubleMuon_Run2016B-03Feb2017-v2" , "/DoubleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016B_03Feb2017_v2  = kreator.makeDataComponent("Tau_Run2016B-03Feb2017-v2" , "/Tau/Run2016B-03Feb2017_ver2-v2/MINIAOD"    , "CMS", ".*root", json)
+
+dataSamples_Run2016B_03Feb2017_v2 = [JetHT_Run2016B_03Feb2017_v2, HTMHT_Run2016B_03Feb2017_v2, MET_Run2016B_03Feb2017_v2, SingleElectron_Run2016B_03Feb2017_v2, SingleMuon_Run2016B_03Feb2017_v2, SinglePhoton_Run2016B_03Feb2017_v2, DoubleEG_Run2016B_03Feb2017_v2, MuonEG_Run2016B_03Feb2017_v2, DoubleMuon_Run2016B_03Feb2017_v2, Tau_Run2016B_03Feb2017_v2]
+
+### ----------------------------- Run2016C 03Feb2017 ----------------------------------------
+
+JetHT_Run2016C_03Feb2017          = kreator.makeDataComponent("JetHT_Run2016C_03Feb2017"         , "/JetHT/Run2016C-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016C_03Feb2017          = kreator.makeDataComponent("HTMHT_Run2016C_03Feb2017"         , "/HTMHT/Run2016C-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016C_03Feb2017            = kreator.makeDataComponent("MET_Run2016C_03Feb2017"           , "/MET/Run2016C-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016C_03Feb2017 = kreator.makeDataComponent("SingleElectron_Run2016C_03Feb2017", "/SingleElectron/Run2016C-03Feb2017-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016C_03Feb2017     = kreator.makeDataComponent("SingleMuon_Run2016C_03Feb2017"    , "/SingleMuon/Run2016C-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016C_03Feb2017   = kreator.makeDataComponent("SinglePhoton_Run2016C_03Feb2017"  , "/SinglePhoton/Run2016C-03Feb2017-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016C_03Feb2017       = kreator.makeDataComponent("DoubleEG_Run2016C_03Feb2017"      , "/DoubleEG/Run2016C-03Feb2017-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016C_03Feb2017         = kreator.makeDataComponent("MuonEG_Run2016C_03Feb2017"        , "/MuonEG/Run2016C-03Feb2017-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016C_03Feb2017     = kreator.makeDataComponent("DoubleMuon_Run2016C_03Feb2017"    , "/DoubleMuon/Run2016C-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016C_03Feb2017            = kreator.makeDataComponent("Tau_Run2016C_03Feb2017"           , "/Tau/Run2016C-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+
+dataSamples_Run2016C_03Feb2017 = [JetHT_Run2016C_03Feb2017, HTMHT_Run2016C_03Feb2017, MET_Run2016C_03Feb2017, SingleElectron_Run2016C_03Feb2017, SingleMuon_Run2016C_03Feb2017, SinglePhoton_Run2016C_03Feb2017, DoubleEG_Run2016C_03Feb2017, MuonEG_Run2016C_03Feb2017, DoubleMuon_Run2016C_03Feb2017, Tau_Run2016C_03Feb2017]
+
+
+### ----------------------------- Run2016D 03Feb2017 v2 ----------------------------------------
+
+JetHT_Run2016D_03Feb2017          = kreator.makeDataComponent("JetHT_Run2016D_03Feb2017"         , "/JetHT/Run2016D-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016D_03Feb2017          = kreator.makeDataComponent("HTMHT_Run2016D_03Feb2017"         , "/HTMHT/Run2016D-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016D_03Feb2017            = kreator.makeDataComponent("MET_Run2016D_03Feb2017"           , "/MET/Run2016D-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016D_03Feb2017 = kreator.makeDataComponent("SingleElectron_Run2016D_03Feb2017", "/SingleElectron/Run2016D-03Feb2017-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016D_03Feb2017     = kreator.makeDataComponent("SingleMuon_Run2016D_03Feb2017"    , "/SingleMuon/Run2016D-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016D_03Feb2017   = kreator.makeDataComponent("SinglePhoton_Run2016D_03Feb2017"  , "/SinglePhoton/Run2016D-03Feb2017-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016D_03Feb2017       = kreator.makeDataComponent("DoubleEG_Run2016D_03Feb2017"      , "/DoubleEG/Run2016D-03Feb2017-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016D_03Feb2017         = kreator.makeDataComponent("MuonEG_Run2016D_03Feb2017"        , "/MuonEG/Run2016D-03Feb2017-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016D_03Feb2017     = kreator.makeDataComponent("DoubleMuon_Run2016D_03Feb2017"    , "/DoubleMuon/Run2016D-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016D_03Feb2017            = kreator.makeDataComponent("Tau_Run2016D_03Feb2017"           , "/Tau/Run2016D-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+
+dataSamples_Run2016D_03Feb2017 = [JetHT_Run2016D_03Feb2017, HTMHT_Run2016D_03Feb2017, MET_Run2016D_03Feb2017, SingleElectron_Run2016D_03Feb2017, SingleMuon_Run2016D_03Feb2017, SinglePhoton_Run2016D_03Feb2017, DoubleEG_Run2016D_03Feb2017, MuonEG_Run2016D_03Feb2017, DoubleMuon_Run2016D_03Feb2017, Tau_Run2016D_03Feb2017]
+
+### ----------------------------- Run2016E 03Feb2017 v2 ----------------------------------------
+
+JetHT_Run2016E_03Feb2017          = kreator.makeDataComponent("JetHT_Run2016E_03Feb2017"         , "/JetHT/Run2016E-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016E_03Feb2017          = kreator.makeDataComponent("HTMHT_Run2016E_03Feb2017"         , "/HTMHT/Run2016E-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016E_03Feb2017            = kreator.makeDataComponent("MET_Run2016E_03Feb2017"           , "/MET/Run2016E-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016E_03Feb2017 = kreator.makeDataComponent("SingleElectron_Run2016E_03Feb2017", "/SingleElectron/Run2016E-03Feb2017-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016E_03Feb2017     = kreator.makeDataComponent("SingleMuon_Run2016E_03Feb2017"    , "/SingleMuon/Run2016E-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016E_03Feb2017   = kreator.makeDataComponent("SinglePhoton_Run2016E_03Feb2017"  , "/SinglePhoton/Run2016E-03Feb2017-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016E_03Feb2017       = kreator.makeDataComponent("DoubleEG_Run2016E_03Feb2017"      , "/DoubleEG/Run2016E-03Feb2017-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016E_03Feb2017         = kreator.makeDataComponent("MuonEG_Run2016E_03Feb2017"        , "/MuonEG/Run2016E-03Feb2017-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016E_03Feb2017     = kreator.makeDataComponent("DoubleMuon_Run2016E_03Feb2017"    , "/DoubleMuon/Run2016E-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016E_03Feb2017            = kreator.makeDataComponent("Tau_Run2016E_03Feb2017"           , "/Tau/Run2016E-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+
+dataSamples_Run2016E_03Feb2017 = [JetHT_Run2016E_03Feb2017, HTMHT_Run2016E_03Feb2017, MET_Run2016E_03Feb2017, SingleElectron_Run2016E_03Feb2017, SingleMuon_Run2016E_03Feb2017, SinglePhoton_Run2016E_03Feb2017, DoubleEG_Run2016E_03Feb2017, MuonEG_Run2016E_03Feb2017, DoubleMuon_Run2016E_03Feb2017, Tau_Run2016E_03Feb2017]
+
+
+### ----------------------------- Run2016F 03Feb2017 v1 ----------------------------------------
+
+JetHT_Run2016F_03Feb2017          = kreator.makeDataComponent("JetHT_Run2016F_03Feb2017"         , "/JetHT/Run2016F-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016F_03Feb2017          = kreator.makeDataComponent("HTMHT_Run2016F_03Feb2017"         , "/HTMHT/Run2016F-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016F_03Feb2017            = kreator.makeDataComponent("MET_Run2016F_03Feb2017"           , "/MET/Run2016F-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016F_03Feb2017 = kreator.makeDataComponent("SingleElectron_Run2016F_03Feb2017", "/SingleElectron/Run2016F-03Feb2017-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016F_03Feb2017     = kreator.makeDataComponent("SingleMuon_Run2016F_03Feb2017"    , "/SingleMuon/Run2016F-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016F_03Feb2017   = kreator.makeDataComponent("SinglePhoton_Run2016F_03Feb2017"  , "/SinglePhoton/Run2016F-03Feb2017-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016F_03Feb2017       = kreator.makeDataComponent("DoubleEG_Run2016F_03Feb2017"      , "/DoubleEG/Run2016F-03Feb2017-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016F_03Feb2017         = kreator.makeDataComponent("MuonEG_Run2016F_03Feb2017"        , "/MuonEG/Run2016F-03Feb2017-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016F_03Feb2017     = kreator.makeDataComponent("DoubleMuon_Run2016F_03Feb2017"    , "/DoubleMuon/Run2016F-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016F_03Feb2017            = kreator.makeDataComponent("Tau_Run2016F_03Feb2017"           , "/Tau/Run2016F-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+
+dataSamples_Run2016F_03Feb2017 = [JetHT_Run2016F_03Feb2017, HTMHT_Run2016F_03Feb2017, MET_Run2016F_03Feb2017, SingleElectron_Run2016F_03Feb2017, SingleMuon_Run2016F_03Feb2017, SinglePhoton_Run2016F_03Feb2017, DoubleEG_Run2016F_03Feb2017, MuonEG_Run2016F_03Feb2017, DoubleMuon_Run2016F_03Feb2017, Tau_Run2016F_03Feb2017]
+
+### ----------------------------- Run2016G 03Feb2017 v1 ----------------------------------------
+
+JetHT_Run2016G_03Feb2017          = kreator.makeDataComponent("JetHT_Run2016G_03Feb2017"         , "/JetHT/Run2016G-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016G_03Feb2017          = kreator.makeDataComponent("HTMHT_Run2016G_03Feb2017"         , "/HTMHT/Run2016G-03Feb2017-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016G_03Feb2017            = kreator.makeDataComponent("MET_Run2016G_03Feb2017"           , "/MET/Run2016G-03Feb2017-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016G_03Feb2017 = kreator.makeDataComponent("SingleElectron_Run2016G_03Feb2017", "/SingleElectron/Run2016G-03Feb2017-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016G_03Feb2017     = kreator.makeDataComponent("SingleMuon_Run2016G_03Feb2017"    , "/SingleMuon/Run2016G-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016G_03Feb2017   = kreator.makeDataComponent("SinglePhoton_Run2016G_03Feb2017"  , "/SinglePhoton/Run2016G-03Feb2017-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016G_03Feb2017       = kreator.makeDataComponent("DoubleEG_Run2016G_03Feb2017"      , "/DoubleEG/Run2016G-03Feb2017-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016G_03Feb2017        = kreator.makeDataComponent("MuonEG_Run2016G_03Feb2017"        , "/MuonEG/Run2016G-03Feb2017-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016G_03Feb2017     = kreator.makeDataComponent("DoubleMuon_Run2016G_03Feb2017"    , "/DoubleMuon/Run2016G-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016G_03Feb2017     = kreator.makeDataComponent("Tau_Run2016G_03Feb2017"    , "/Tau/Run2016G-03Feb2017-v1/MINIAOD"    , "CMS", ".*root", json)
+
+dataSamples_Run2016G_03Feb2017 = [JetHT_Run2016G_03Feb2017, HTMHT_Run2016G_03Feb2017, MET_Run2016G_03Feb2017, SingleElectron_Run2016G_03Feb2017, SingleMuon_Run2016G_03Feb2017, SinglePhoton_Run2016G_03Feb2017, DoubleEG_Run2016G_03Feb2017, MuonEG_Run2016G_03Feb2017, DoubleMuon_Run2016G_03Feb2017, Tau_Run2016G_03Feb2017]
+
+### ----------------------------- Run2016H 03Feb2017_ver2-v1 ----------------------------------------
+
+JetHT_Run2016H_03Feb2017_v2          = kreator.makeDataComponent("JetHT_Run2016H_03Feb2017_v2"         , "/JetHT/Run2016H-03Feb2017_ver2-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016H_03Feb2017_v2          = kreator.makeDataComponent("HTMHT_Run2016H_03Feb2017_v2"         , "/HTMHT/Run2016H-03Feb2017_ver2-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016H_03Feb2017_v2            = kreator.makeDataComponent("MET_Run2016H_03Feb2017_v2"           , "/MET/Run2016H-03Feb2017_ver2-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016H_03Feb2017_v2 = kreator.makeDataComponent("SingleElectron_Run2016H_03Feb2017_v2", "/SingleElectron/Run2016H-03Feb2017_ver2-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016H_03Feb2017_v2     = kreator.makeDataComponent("SingleMuon_Run2016H_03Feb2017_v2"    , "/SingleMuon/Run2016H-03Feb2017_ver2-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016H_03Feb2017_v2   = kreator.makeDataComponent("SinglePhoton_Run2016H_03Feb2017_v2"  , "/SinglePhoton/Run2016H-03Feb2017_ver2-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016H_03Feb2017_v2       = kreator.makeDataComponent("DoubleEG_Run2016H_03Feb2017_v2"      , "/DoubleEG/Run2016H-03Feb2017_ver2-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016H_03Feb2017_v2        = kreator.makeDataComponent("MuonEG_Run2016H_03Feb2017_v2"        , "/MuonEG/Run2016H-03Feb2017_ver2-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016H_03Feb2017_v2     = kreator.makeDataComponent("DoubleMuon_Run2016H_03Feb2017_v2"    , "/DoubleMuon/Run2016H-03Feb2017_ver2-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016H_03Feb2017_v2     = kreator.makeDataComponent("Tau_Run2016H_03Feb2017_v2"    , "/Tau/Run2016H-03Feb2017_ver2-v1/MINIAOD"    , "CMS", ".*root", json)
+
+dataSamples_Run2016H_03Feb2017_v2 = [JetHT_Run2016H_03Feb2017_v2, HTMHT_Run2016H_03Feb2017_v2, MET_Run2016H_03Feb2017_v2, SingleElectron_Run2016H_03Feb2017_v2, SingleMuon_Run2016H_03Feb2017_v2, SinglePhoton_Run2016H_03Feb2017_v2, DoubleEG_Run2016H_03Feb2017_v2, MuonEG_Run2016H_03Feb2017_v2, DoubleMuon_Run2016H_03Feb2017_v2, Tau_Run2016H_03Feb2017_v2]
+
+### ----------------------------- Run2016H 03Feb2017_ver3-v1 ----------------------------------------
+
+JetHT_Run2016H_03Feb2017_v3          = kreator.makeDataComponent("JetHT_Run2016H_03Feb2017_v3"         , "/JetHT/Run2016H-03Feb2017_ver3-v1/MINIAOD"         , "CMS", ".*root", json)
+HTMHT_Run2016H_03Feb2017_v3          = kreator.makeDataComponent("HTMHT_Run2016H_03Feb2017_v3"         , "/HTMHT/Run2016H-03Feb2017_ver3-v1/MINIAOD"         , "CMS", ".*root", json)
+MET_Run2016H_03Feb2017_v3            = kreator.makeDataComponent("MET_Run2016H_03Feb2017_v3"           , "/MET/Run2016H-03Feb2017_ver3-v1/MINIAOD"           , "CMS", ".*root", json)
+SingleElectron_Run2016H_03Feb2017_v3 = kreator.makeDataComponent("SingleElectron_Run2016H_03Feb2017_v3", "/SingleElectron/Run2016H-03Feb2017_ver3-v1/MINIAOD", "CMS", ".*root", json)
+SingleMuon_Run2016H_03Feb2017_v3     = kreator.makeDataComponent("SingleMuon_Run2016H_03Feb2017_v3"    , "/SingleMuon/Run2016H-03Feb2017_ver3-v1/MINIAOD"    , "CMS", ".*root", json)
+SinglePhoton_Run2016H_03Feb2017_v3   = kreator.makeDataComponent("SinglePhoton_Run2016H_03Feb2017_v3"  , "/SinglePhoton/Run2016H-03Feb2017_ver3-v1/MINIAOD"  , "CMS", ".*root", json)
+DoubleEG_Run2016H_03Feb2017_v3       = kreator.makeDataComponent("DoubleEG_Run2016H_03Feb2017_v3"      , "/DoubleEG/Run2016H-03Feb2017_ver3-v1/MINIAOD"      , "CMS", ".*root", json)
+MuonEG_Run2016H_03Feb2017_v3        = kreator.makeDataComponent("MuonEG_Run2016H_03Feb2017_v3"        , "/MuonEG/Run2016H-03Feb2017_ver3-v1/MINIAOD"        , "CMS", ".*root", json)
+DoubleMuon_Run2016H_03Feb2017_v3     = kreator.makeDataComponent("DoubleMuon_Run2016H_03Feb2017_v3"    , "/DoubleMuon/Run2016H-03Feb2017_ver3-v1/MINIAOD"    , "CMS", ".*root", json)
+Tau_Run2016H_03Feb2017_v3     = kreator.makeDataComponent("Tau_Run2016H_03Feb2017_v3"    , "/Tau/Run2016H-03Feb2017_ver3-v1/MINIAOD"    , "CMS", ".*root", json)
+
+dataSamples_Run2016H_03Feb2017_v3 = [JetHT_Run2016H_03Feb2017_v3, HTMHT_Run2016H_03Feb2017_v3, MET_Run2016H_03Feb2017_v3, SingleElectron_Run2016H_03Feb2017_v3, SingleMuon_Run2016H_03Feb2017_v3, SinglePhoton_Run2016H_03Feb2017_v3, DoubleEG_Run2016H_03Feb2017_v3, MuonEG_Run2016H_03Feb2017_v3, DoubleMuon_Run2016H_03Feb2017_v3, Tau_Run2016H_03Feb2017_v3]
+
+samples = dataSamples_PromptReco
+
+### Summary of 03Feb2017
+dataSamples_03Feb2017 = dataSamples_Run2016B_03Feb2017_v1 + dataSamples_Run2016B_03Feb2017_v2 + dataSamples_Run2016C_03Feb2017 + dataSamples_Run2016D_03Feb2017 + dataSamples_Run2016E_03Feb2017 + dataSamples_Run2016F_03Feb2017 + dataSamples_Run2016G_03Feb2017 + dataSamples_Run2016H_03Feb2017_v2 + dataSamples_Run2016H_03Feb2017_v3
+
+
+dataSamples = dataSamples_PromptReco + dataSamples_23Sep2016 + dataSamples_03Feb2017
 samples = dataSamples
 
 ### ---------------------------------------------------------------------

--- a/RootTools/python/samples/samples_13TeV_DATA2016.py
+++ b/RootTools/python/samples/samples_13TeV_DATA2016.py
@@ -262,21 +262,6 @@ dataSamples_23Sep2016 = dataSamples_Run2016B_23Sep2016 + dataSamples_Run2016C_23
 ### Dataset corresponding to the full Run2016 with re-reco + prompt
 dataSamples_23Sep2016PlusPrompt = dataSamples_23Sep2016 + dataSamples_Run2016H_v2 + dataSamples_Run2016H_v3
 
-### ----------------------------- Run2016B v1 03Feb2017 ----------------------------------------
-
-JetHT_Run2016B_03Feb2017_v1       = kreator.makeDataComponent("JetHT_Run2016B_03Feb2017_v1"      , "/JetHT/Run2016B-03Feb2017_ver1-v1/MINIAOD"         , "CMS", ".*root", json)
-HTMHT_Run2016B_03Feb2017_v1       = kreator.makeDataComponent("HTMHT_Run2016B_03Feb2017_v1"      , "/HTMHT/Run2016B-03Feb2017_ver1-v1/MINIAOD"         , "CMS", ".*root", json)
-MET_Run2016B_03Feb2017_v1         = kreator.makeDataComponent("MET_Run2016B_03Feb2017_v1"        , "/MET/Run2016B-03Feb2017_ver1-v1/MINIAOD"           , "CMS", ".*root", json)
-SingleElectron_Run2016B_03Feb2017_v1 = kreator.makeDataComponent("SingleElectron_Run2016B_03Feb2017_v1", "/SingleElectron/Run2016B-03Feb2017_ver1-v1/MINIAOD", "CMS", ".*root", json)
-SingleMuon_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("SingleMuon_Run2016B_03Feb2017_v1" , "/SingleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
-SinglePhoton_Run2016B_03Feb2017_v1= kreator.makeDataComponent("SinglePhoton_Run2016B_03Feb2017_v1"  , "/SinglePhoton/Run2016B-03Feb2017_ver1-v1/MINIAOD"  , "CMS", ".*root", json)
-DoubleEG_Run2016B_03Feb2017_v1    = kreator.makeDataComponent("DoubleEG_Run2016B_03Feb2017_v1"   , "/DoubleEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"      , "CMS", ".*root", json)
-MuonEG_Run2016B_03Feb2017_v1     = kreator.makeDataComponent("MuonEG_Run2016B_03Feb2017_v1"     , "/MuonEG/Run2016B-03Feb2017_ver1-v1/MINIAOD"        , "CMS", ".*root", json)
-DoubleMuon_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("DoubleMuon_Run2016B_03Feb2017_v1" , "/DoubleMuon/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
-Tau_Run2016B_03Feb2017_v1  = kreator.makeDataComponent("Tau_Run2016B_03Feb2017_v1" , "/Tau/Run2016B-03Feb2017_ver1-v1/MINIAOD"    , "CMS", ".*root", json)
-
-dataSamples_Run2016B_03Feb2017_v1 = [JetHT_Run2016B_03Feb2017_v1, HTMHT_Run2016B_03Feb2017_v1, MET_Run2016B_03Feb2017_v1, SingleElectron_Run2016B_03Feb2017_v1, SingleMuon_Run2016B_03Feb2017_v1, SinglePhoton_Run2016B_03Feb2017_v1, DoubleEG_Run2016B_03Feb2017_v1, MuonEG_Run2016B_03Feb2017_v1, DoubleMuon_Run2016B_03Feb2017_v1, Tau_Run2016B_03Feb2017_v1]
-
 ### ----------------------------- Run2016B v2 03Feb2017 ----------------------------------------
 
 JetHT_Run2016B_03Feb2017_v2       = kreator.makeDataComponent("JetHT_Run2016B_03Feb2017_v2"      , "/JetHT/Run2016B-03Feb2017_ver2-v2/MINIAOD"         , "CMS", ".*root", json)
@@ -402,7 +387,7 @@ dataSamples_Run2016H_03Feb2017_v3 = [JetHT_Run2016H_03Feb2017_v3, HTMHT_Run2016H
 samples = dataSamples_PromptReco
 
 ### Summary of 03Feb2017
-dataSamples_03Feb2017 = dataSamples_Run2016B_03Feb2017_v1 + dataSamples_Run2016B_03Feb2017_v2 + dataSamples_Run2016C_03Feb2017 + dataSamples_Run2016D_03Feb2017 + dataSamples_Run2016E_03Feb2017 + dataSamples_Run2016F_03Feb2017 + dataSamples_Run2016G_03Feb2017 + dataSamples_Run2016H_03Feb2017_v2 + dataSamples_Run2016H_03Feb2017_v3
+dataSamples_03Feb2017 = dataSamples_Run2016B_03Feb2017_v2 + dataSamples_Run2016C_03Feb2017 + dataSamples_Run2016D_03Feb2017 + dataSamples_Run2016E_03Feb2017 + dataSamples_Run2016F_03Feb2017 + dataSamples_Run2016G_03Feb2017 + dataSamples_Run2016H_03Feb2017_v2 + dataSamples_Run2016H_03Feb2017_v3
 
 
 dataSamples = dataSamples_PromptReco + dataSamples_23Sep2016 + dataSamples_03Feb2017


### PR DESCRIPTION
added run H
updated datasets to 03Feb2017 version
silenced a warning coming from :
https://github.com/steggema/cmgtools-lite/blob/825_HTT/H2TauTau/interface/DiTauObjectFactory.h#L156
because it was making log file take a lot of disk space. The warning was about the diTau object not being built from metCands collection but from legCands collection. Is that not supposed to happen? Should I look into it?
@cbern